### PR TITLE
Dockerizing

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/Python-Feeds.iml
+++ b/.idea/Python-Feeds.iml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="TemplatesService">
+    <option name="TEMPLATE_FOLDERS">
+      <list>
+        <option value="$MODULE_DIR$/SeeThru_Feeds/Core/templates" />
+      </list>
+    </option>
+  </component>
+</module>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,14 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <value>
+          <list size="1">
+            <item index="0" class="java.lang.String" itemvalue="psycopg2" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Python-Feeds.iml" filepath="$PROJECT_DIR$/.idea/Python-Feeds.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/runConfigurations/start.xml
+++ b/.idea/runConfigurations/start.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="start" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
+    <deployment type="docker-compose.yml">
+      <settings>
+        <option name="sourceFilePath" value="docker-compose.yml" />
+      </settings>
+    </deployment>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,3 @@ COPY . .
 
 CMD ["python"]
 
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.8.2-slim-buster
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python"]
+
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
-
+RUN python setup.py install
 CMD ["python"]
 

--- a/README.rst
+++ b/README.rst
@@ -151,7 +151,7 @@ The Script_Name occurences will be replaced with the name that you gave.
 Any properties that are needed by the Script should be declared in the class using the ``FillableProperty`` and ``ResultProperty`` objects, these will be defined later but as a wuick summary, they can ensure that conditions enfored on the values needed before execution.
 An example of a FillableProperty would be the ``host`` used in a test, this would have the paremeters ``required=True`` and ``oftype=str`` to say that the property is required and must be of type string.
 
-Any propeties that are the result of your tests should be stored in ResultProperties, this is so that users of your script know what your script produces and to provice a common interface for accessing properties of a script.
+Any properties that are the result of your tests should be stored in ResultProperties, this is so that users of your script know what your script produces and to provice a common interface for accessing properties of a script.
 An example of a ResultProperty would be a ``latency`` property, which stores the latency of a ping test.
 
 ``Script_Evaluate`` is where your script's test results should get evaluated into red, amber or green and a message produced. The method takes a result paramater which will be of type ScriptResult. This object stores the colour and message of the script.

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,9 @@ If you have docker on your system, use the included docker config (Dockerfile an
 
 `docker-compose up -d`
 
-That will download the necessary images and bring the container up. Once it is up,
+That will download the necessary images and bring the container up. Once it is up, the following command
+gives you a bash shell which uses that python. At a later time, we might add tests to run through this
+container in CI/CD created environments.
 
 `docker-compose exec python_feeds /bin/bash`
 

--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,20 @@ To install the latest development version, run:
 
 This will install the SeeThru Feeds module. You can also install the module in a ``virtualenv`` if you would like to do so.
 
+Alternative Installation (WIP)
+==============================
+
+If you have docker on your system, use the included docker config (Dockerfile and docker-compose.yml) like this:
+
+`docker-compose up -d`
+
+That will download the necessary images and bring the container up. Once it is up,
+
+`docker-compose exec python_feeds /bin/bash`
+
+Why use docker-compose? It gives us a friendly service name (python_feeds) and at a later time, when we set up a
+network of services to do automated testing, it will be useful.
+
 Getting Started
 ===============
 

--- a/SeeThru_Feeds/Library/Components/SNMP.py
+++ b/SeeThru_Feeds/Library/Components/SNMP.py
@@ -1,6 +1,6 @@
 from SeeThru_Feeds.Model.Components.ComponentBase import ComponentBase
 from SeeThru_Feeds.Model.Properties.Properties import FillableProperty, ResultProperty
-import pysnmp.hlapi import *
+from pysnmp.hlapi import *
 
 class SNMPWalkToOID(ComponentBase):
     SNMP_HOST = FillableProperty(name="snmp_host", required=True, ofType=str)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  simple_calc:
+    build: .
+    stdin_open: true
+    tty: true
+
+
+
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,7 @@
 version: '3'
 services:
-  simple_calc:
+  python_feeds:
     build: .
     stdin_open: true
     tty: true
-
-
-
-
 


### PR DESCRIPTION
Some comments about the changes here:

1. Main change is just the ability to run this code inside a docker container with a standard python 3.8.

2. Some changes to README to describe that.

3. One import bug fixed in SNMP.py

4. .idea/ files. There are some opinions that project files should be shared, but JetBrains supports it now and PyCharm professional is a good tool to use. It has already discovered a lot of style bugs in the code (and Nick mentioned it). It will help to refactor those without problems. 