### PR TITLE
Prepare is now called when a script is ran

### DIFF
--- a/SeeThru_Feeds/Core/SeeThru_Feed.py
+++ b/SeeThru_Feeds/Core/SeeThru_Feed.py
@@ -190,7 +190,8 @@ class SeeThru_Feed():
 
             scriptInstance.SetInternalAlias(Script_Name)
             # Runs the script
-            scriptInstance.RunScript()\
+            scriptInstance.Prepare()\
+                .RunScript()\
                 .SetOutputPath(script[Script_Name]['Meta']['Script_Output_Path'])\
                 .EvaluateScript()\
                 .LogOutput()\


### PR DESCRIPTION
There is an overridable Prepare function in the script, previously this wasn't be called by runfeedscheme which means that the override wouldn't be executed, this is now fixed